### PR TITLE
Add SlackEventMiddleware class to C# project

### DIFF
--- a/C#/Botkit/botbuilder-slack-adapter/SlackEventMiddleware.cs
+++ b/C#/Botkit/botbuilder-slack-adapter/SlackEventMiddleware.cs
@@ -1,7 +1,7 @@
-/**
- * Copyright(c) Microsoft Corporation. All rights reserved.
- * Licensed under the MIT License.
- */
+//
+// Copyright(c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+// 
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Schema;
 using System;
@@ -11,28 +11,13 @@ using System.Threading.Tasks;
 
 namespace botbuilder_slack_adapter
 {
-    /**
-     * A middleware for Botkit developers using the BotBuilder SlackAdapter class.
-     * This middleware causes Botkit to emit message events by their `type` or `subtype` field rather than their default BotBuilder Activity type (limited to message or event).
-     * This keeps the new Botkit behavior consistent withprevious versions, and provides helpful filtering on the many event types that Slack sends.
-     * To use this, bind it to the adapter before creating the Botkit controller:
-     * ```C#
-     * const var adapter = new SlackAdapter(options);
-     * adapter.use(new SlackEventMiddleware());
-     * const var controller = new Botkit({
-     *      adapter: adapter,
-     *      // ...
-     * });
-     *
-     * // can bind directly to channel_join (which starts as a message with type message and subtype channel_join)
-     * controller.on('channel_join', async(bot, message) => {
-     *  // send a welcome
-     * });
-     * ```
-     */
-
     class SlackEventMiddleware : MiddlewareSet
     {
+        /// <summary>
+        /// A middleware for Botkit developers using the BotBuilder SlackAdapter class.
+        /// This middleware causes Botkit to emit message events by their `type` or `subtype` field rather than their default BotBuilder Activity type(limited to message or event).
+        /// This keeps the new Botkit behavior consistent withprevious versions, and provides helpful filtering on the many event types that Slack sends.
+        /// </summary>
         public async void OnTurn(TurnContext context, Func<Task<object>> next)
         {
             if ((context.Activity.Type == ActivityTypes.Event))

--- a/C#/Botkit/botbuilder-slack-adapter/SlackEventMiddleware.cs
+++ b/C#/Botkit/botbuilder-slack-adapter/SlackEventMiddleware.cs
@@ -7,18 +7,19 @@ using Microsoft.Bot.Schema;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace botbuilder_slack_adapter
 {
-    class SlackEventMiddleware : MiddlewareSet
+    public class SlackEventMiddleware : MiddlewareSet
     {
         /// <summary>
         /// A middleware for Botkit developers using the BotBuilder SlackAdapter class.
         /// This middleware causes Botkit to emit message events by their `type` or `subtype` field rather than their default BotBuilder Activity type(limited to message or event).
         /// This keeps the new Botkit behavior consistent withprevious versions, and provides helpful filtering on the many event types that Slack sends.
         /// </summary>
-        public async void OnTurn(TurnContext context, Func<Task<object>> next)
+        public async void OnTurn(TurnContext context, NextDelegate next, CancellationToken cancellationToken = default(CancellationToken))
         {
             if ((context.Activity.Type == ActivityTypes.Event))
             {
@@ -33,7 +34,7 @@ namespace botbuilder_slack_adapter
                 }
             }
 
-            await next();
+            await next(cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/C#/Botkit/botbuilder-slack-adapter/SlackEventMiddleware.cs
+++ b/C#/Botkit/botbuilder-slack-adapter/SlackEventMiddleware.cs
@@ -1,0 +1,54 @@
+/**
+ * Copyright(c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Schema;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace botbuilder_slack_adapter
+{
+    /**
+     * A middleware for Botkit developers using the BotBuilder SlackAdapter class.
+     * This middleware causes Botkit to emit message events by their `type` or `subtype` field rather than their default BotBuilder Activity type (limited to message or event).
+     * This keeps the new Botkit behavior consistent withprevious versions, and provides helpful filtering on the many event types that Slack sends.
+     * To use this, bind it to the adapter before creating the Botkit controller:
+     * ```C#
+     * const var adapter = new SlackAdapter(options);
+     * adapter.use(new SlackEventMiddleware());
+     * const var controller = new Botkit({
+     *      adapter: adapter,
+     *      // ...
+     * });
+     *
+     * // can bind directly to channel_join (which starts as a message with type message and subtype channel_join)
+     * controller.on('channel_join', async(bot, message) => {
+     *  // send a welcome
+     * });
+     * ```
+     */
+
+    class SlackEventMiddleware : MiddlewareSet
+    {
+        public async void OnTurn(TurnContext context, Func<Task<object>> next)
+        {
+            if ((context.Activity.Type == ActivityTypes.Event))
+            {
+                // Handle message sub-types
+                if ((context.Activity.ChannelData as dynamic)?.subtype != null)
+                {
+                    (context.Activity.ChannelData as dynamic).botkitEventType = (context.Activity.ChannelData as dynamic).subtype;
+                }
+                else if ((context.Activity.ChannelData as dynamic)?.type != null)
+                {
+                    (context.Activity.ChannelData as dynamic).botkitEventType = (context.Activity.ChannelData as dynamic).type;
+                }
+            }
+
+            await next();
+        }
+    }
+}

--- a/C#/Botkit/botbuilder-slack-adapter/botbuilder-slack-adapter.csproj
+++ b/C#/Botkit/botbuilder-slack-adapter/botbuilder-slack-adapter.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bot.Builder" Version="4.4.3" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.4.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Added file and class `SlackEventMiddleware`.

**Proposed changes:**
Cast `ChannelData` as _dynamic_ as it is in its parent interface. At least until when-and-if the C# `Activity` class gets modified by its maintainers. This is now a workaround to help translate this variable's usage from Typescript.