### PR TITLE
[SlackAdapter] Small changes to DialogElement and SlackDialog

### DIFF
--- a/C#/Botkit/Microsoft.BotKit.Adapters.Slack/DialogElement.cs
+++ b/C#/Botkit/Microsoft.BotKit.Adapters.Slack/DialogElement.cs
@@ -11,7 +11,7 @@ namespace Microsoft.BotKit.Adapters.Slack
         public string Name { get; set; }
         public string Value { get; set; }
         public Dictionary<string, string> OptionList { get; set; }
-        public object Options { get; set; }
+        public ISlackAdapterOptions Options { get; set; }
         public string Type { get; set; }
         public string Subtype { get; set; }
     }

--- a/C#/Botkit/Microsoft.BotKit.Adapters.Slack/SlackDialog.cs
+++ b/C#/Botkit/Microsoft.BotKit.Adapters.Slack/SlackDialog.cs
@@ -83,7 +83,7 @@ namespace Microsoft.BotKit.Adapters.Slack
 
             element = label;
                
-            if (options.GetType().ToString() == "DialogElement")
+            if (options.GetType() == typeof(DialogElement))
             {
                 element = (DialogElement)options;
             }
@@ -112,7 +112,7 @@ namespace Microsoft.BotKit.Adapters.Slack
                 Subtype = subtype
             };
 
-            if (options.GetType().ToString() == "DialogElement")
+            if (options.GetType() == typeof(DialogElement))
             {
                 element = (DialogElement)options;
             }
@@ -182,7 +182,7 @@ namespace Microsoft.BotKit.Adapters.Slack
 
             element = label;
 
-            if (options.GetType().ToString() == "DialogElement")
+            if (options.GetType() == typeof(DialogElement))
             {
                 element = (DialogElement)options;
             }
@@ -211,7 +211,7 @@ namespace Microsoft.BotKit.Adapters.Slack
                 Subtype = subtype
             };
 
-            if (options.GetType().ToString() == "DialogElement")
+            if (options.GetType() == typeof(DialogElement))
             {
                 element = (DialogElement)options;
             }
@@ -240,7 +240,7 @@ namespace Microsoft.BotKit.Adapters.Slack
                 OptionList = optionList,
             };
 
-            if (options.GetType().ToString() == "DialogElement")
+            if (options.GetType() == typeof(DialogElement))
             {
                 element = (DialogElement)options;
             }
@@ -253,13 +253,13 @@ namespace Microsoft.BotKit.Adapters.Slack
         /// </summary>
         public string AsString()
         {
-            return JsonConvert.ToString(this.data.ToString());
+            return JsonConvert.ToString(data.ToString());
         }
 
         /// <summary>
         /// Get the dialog object for use with bot.replyWithDialog() 
         /// </summary>
-        public object AsObject()
+        public DialogData AsObject()
         {
             return data;
         }

--- a/C#/Botkit/Microsoft.BotKit.Adapters.Slack/SlackDialog.cs
+++ b/C#/Botkit/Microsoft.BotKit.Adapters.Slack/SlackDialog.cs
@@ -57,7 +57,7 @@ namespace Microsoft.BotKit.Adapters.Slack
         /// <param name="value">Value for the callback_id.</param>
         public void SetCallbackId(string value)
         {
-            data.Title = value;
+            data.CallbackId = value;
         }
 
         /// <summary>


### PR DESCRIPTION
- Return `ISlackAdapterOptions` en lugar de `object` in `AsObject()`
- Replace
```c#
if (options.GetType().ToString() == "DialogElement") {}
```
with
``` c#
if (options.GetType() == typeof(DialogElement))
```