### PR TITLE
[IBotkitConvoTrigger] Change interface's properties for methods.

### DIFF
--- a/C#/Botkit/Microsoft.BotKit/Conversation/IBotkitConvoTrigger.cs
+++ b/C#/Botkit/Microsoft.BotKit/Conversation/IBotkitConvoTrigger.cs
@@ -1,12 +1,7 @@
 // Copyright(c) Microsoft Corporation.All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace Microsoft.BotKit.Conversation
 {
@@ -15,9 +10,8 @@ namespace Microsoft.BotKit.Conversation
     /// </summary>
     public interface IBotkitConvoTrigger
     {
-        string Type { get; set; }
-        Regex Pattern { get; set; }
-        IBotkitConvoHandler Handler { get; set; }
-        bool Default { get; set; }
+        void BotkitConvoTrigger(IBotkitConvoHandler handler, string type = null, string pattern = null, bool defaultTrigger = false);
+
+        void BotkitConvoTrigger(IBotkitConvoHandler handler, string type = null, Regex pattern = null, bool defaultTrigger = false) ;
     }
 }

--- a/C#/Botkit/Microsoft.BotKit/Core/BotkitConfiguration.cs
+++ b/C#/Botkit/Microsoft.BotKit/Core/BotkitConfiguration.cs
@@ -10,7 +10,7 @@ namespace Microsoft.BotKit.Core
     {
         public string WebhookUri { get; set; }
         public string DialogStateProperty { get; set; }
-        public BotkitFrameworkAdapter Adapter { get; set; } // TO-DO: compare with TS implementation
+        public BotkitBotFrameworkAdapter Adapter { get; set; } // TO-DO: compare with TS implementation
         public Tuple<AdapterKey, string> AdapterConfig { get; set; }
         public IWebserver Webserver { get; set; }
         public IStorage Storage { get; set; }


### PR DESCRIPTION
**Proposed Changes**

- Migrate **_IBotkitConvoTrigger_** properties as methods to solve union types porting used in [TypeScript implementation](https://github.com/southworkscom/botkit/blob/079d82cec35ab6d6d97db7e4738169d366d77e71/packages/botkit/src/conversation.ts#L28).
